### PR TITLE
Replace strict comparaison

### DIFF
--- a/includes/upgrade.class.php
+++ b/includes/upgrade.class.php
@@ -45,7 +45,7 @@ final class DSLC_Upgrade {
 
 		$curr_version = sort( $curr_version );
 
-		if( $curr_version !== $curr_version_db ) {
+		if( $curr_version != $curr_version_db ) {
 
 			// Updated ro current version.
 			update_option( 'dslc_version', $curr_version );


### PR DESCRIPTION
I added a note in my previous commit (#216) regarding this mistake but it was not taken care of.

"Please update line 48, instead of "$curr_version !== $curr_version_db", just use "$curr_version != $curr_version_db"."