### PR TITLE
Escape the download-tag link output in the downloads module

### DIFF
--- a/modules/downloads/module.php
+++ b/modules/downloads/module.php
@@ -5456,7 +5456,7 @@ while ( $dslc_query->have_posts() ) : $dslc_query->the_post();
 																In
 																<?php foreach ( $download_tags as $download_tag ) : $download_tags_count++; ?>
 																	<?php if ( $download_tags_count > 1 ) { echo ', '; } ?>
-																	<a href="<?php echo get_term_link( $download_tag->slug, 'dslc_downloads_tags' ); ?>"><?php echo $download_tag->name; ?></a>
+																	<a href="<?php echo esc_url( get_term_link( $download_tag->slug, 'dslc_downloads_tags' ) ); ?>"><?php echo esc_html( $download_tag->name ); ?></a>
 																<?php endforeach; ?>
 															</div><!-- .dslc-download-tags -->
 
@@ -5559,7 +5559,7 @@ while ( $dslc_query->have_posts() ) : $dslc_query->the_post();
 												In
 												<?php foreach ( $download_tags as $download_tag ) : $download_tags_count++; ?>
 													<?php if ( $download_tags_count > 1 ) { echo ', '; } ?>
-													<a href="<?php echo get_term_link( $download_tag->slug, 'dslc_downloads_tags' ); ?>"><?php echo $download_tag->name; ?></a>
+													<a href="<?php echo esc_url( get_term_link( $download_tag->slug, 'dslc_downloads_tags' ) ); ?>"><?php echo esc_html( $download_tag->name ); ?></a>
 												<?php endforeach; ?>
 											</div><!-- .dslc-download-tags -->
 


### PR DESCRIPTION
Escaping fix in the downloads module. The download-tag links (in both the grid and list render branches) echo `get_term_link()` into the `href` and the term name into the link text without escaping. This wraps the URL in `esc_url()`, matching the `esc_url()` you already use for image `src` values in this same module, and the name in `esc_html()`.

I kept it scoped to just these two identical lines so the change is easy to review, and for valid tags the escaped output is unchanged.

Appreciate the work on Live Composer. Happy to send a small one along.

(full disclosure: AI helped me spot this and check it against the module's own escaping; the change and this note are mine.)
